### PR TITLE
fix: fix the example code for semantic-release-teams

### DIFF
--- a/semantic-release-configs/java/docker-image.releaserc.json
+++ b/semantic-release-configs/java/docker-image.releaserc.json
@@ -35,7 +35,7 @@
     ],
     "@semantic-release/git",
     [
-      "@argo/sematic-release-teams",
+      "@argodevops/semantic-release-teams",
       {
         "packageName": "<YOUR_APP_NAME>"
       }

--- a/semantic-release-configs/java/mvn-deploy.releaserc.json
+++ b/semantic-release-configs/java/mvn-deploy.releaserc.json
@@ -18,7 +18,7 @@
     ],
     "@semantic-release/git",
     [
-      "@argo/sematic-release-teams",
+      "@argodevops/semantic-release-teams",
       {
         "packageName": "<YOUR_APP_NAME>"
       }

--- a/semantic-release-configs/js/docker-image.release.config.js
+++ b/semantic-release-configs/js/docker-image.release.config.js
@@ -29,7 +29,7 @@ const docker = [
 
 const git = "@semantic-release/git";
 
-const teams = ["@argo/sematic-release-teams", { packageName: pkg.name }];
+const teams = ["@argodevops/semantic-release-teams", { packageName: pkg.name }];
 
 module.exports = {
   branches,


### PR DESCRIPTION
Fixed the example code that was incorrectly specifying the `@argodevops/semantic-release-teams` plugin